### PR TITLE
Fix code scanning alert no. 12: Clear text transmission of sensitive cookie

### DIFF
--- a/config.js
+++ b/config.js
@@ -10,7 +10,15 @@ const expressSession = require('express-session');
 
 app.use(helmet());
 app.use(bodyParser.json());
-app.use(expressSession());
+app.use(expressSession({
+    secret: 'your-secret-key',
+    resave: false,
+    saveUninitialized: true,
+    cookie: {
+        secure: process.env.NODE_ENV === 'production',
+        httpOnly: true
+    }
+}));
 app.get('/example', function(req, res) {
     res.end(`I'm in danger!`);
 });


### PR DESCRIPTION
Fixes [https://github.com/eliorpaz/eli-test/security/code-scanning/12](https://github.com/eliorpaz/eli-test/security/code-scanning/12)

To fix the problem, we need to configure the `express-session` middleware to enforce SSL encryption for cookies. This can be done by setting the `secure` attribute to `true` in the session configuration. Additionally, we should ensure that the `httpOnly` attribute is set to prevent client-side scripts from accessing the cookies.

- Modify the `express-session` configuration to include the `secure` and `httpOnly` attributes.
- Ensure that the `secure` attribute is only set to `true` when the application is running in a production environment to avoid issues during local development.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
